### PR TITLE
Replace blur with page visibility api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-interaction-time",
-  "version": "2.2.1",
+  "version": "3.0.0",
   "description": "",
   "keywords": [],
   "main": "dist/browser-interaction-time.umd.js",

--- a/test/e2e/fixtures/index.html
+++ b/test/e2e/fixtures/index.html
@@ -4,74 +4,69 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js">
-<!--<![endif]-->
+  <!--<![endif]-->
 
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <title></title>
-  <meta name="description" content="" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="" />
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title></title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="" />
+  </head>
 
-<body>
-  <h2 class="headline">⏰browser-interaction-time</h2>
-  <script src="../../../dist/browser-interaction-time.umd.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      var appendMessageToDom = text => time => {
-        const element = document.createElement('div')
-        element.className = text
-
-        element.innerHTML = `<span>${text}: ${time} ms</span>`
-        document.body.appendChild(element)
-      }
-
-      var printMarks = measures => {
-        measures.forEach(measure => {
+  <body>
+    <h2 class="headline">⏰browser-interaction-time</h2>
+    <script src="../../../dist/browser-interaction-time.umd.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        var appendMessageToDom = (text) => (time) => {
           const element = document.createElement('div')
-          element.className = measure.name
+          element.className = text
 
-          element.innerHTML = `<span>${measure.name}: ${measure.duration}, ${measure.startTime}</span>`
+          element.innerHTML = `<span>${text}: ${time} ms</span>`
           document.body.appendChild(element)
+        }
+
+        var printMarks = (measures) => {
+          measures.forEach((measure) => {
+            const element = document.createElement('div')
+            element.className = measure.name
+
+            element.innerHTML = `<span>${measure.name}: ${measure.duration}, ${measure.startTime}</span>`
+            document.body.appendChild(element)
+          })
+        }
+
+        var bit = new window.browserInteractionTime({
+          timeIntervalEllapsedCallbacks: [
+            {
+              timeInMilliseconds: 1000,
+              callback: appendMessageToDom('timer-reached-interval'),
+              multiplier: (x) => x * 2,
+            },
+          ],
+          absoluteTimeEllapsedCallbacks: [
+            {
+              timeInMilliseconds: 1000,
+              callback: appendMessageToDom('timer-reached-absolute'),
+              pending: true,
+            },
+            {
+              timeInMilliseconds: 9000,
+              callback: appendMessageToDom('timer-reached-absolute'),
+              pending: true,
+            },
+          ],
+          idleTimeoutMs: 30000,
         })
-      }
+        bit.startTimer()
 
-      var bit = new window.browserInteractionTime({
-        timeIntervalEllapsedCallbacks: [{
-          timeInMilliseconds: 1000,
-          callback: appendMessageToDom('timer-reached-interval'),
-          multiplier: x => x * 2
-        }],
-        absoluteTimeEllapsedCallbacks: [{
-            timeInMilliseconds: 1000,
-            callback: appendMessageToDom('timer-reached-absolute'),
-            pending: true
-          },
-          {
-            timeInMilliseconds: 9000,
-            callback: appendMessageToDom('timer-reached-absolute'),
-            pending: true
-          }
-        ],
-        browserTabInactiveCallbacks: [
-          appendMessageToDom('tab-became-inactive')
-        ],
-        browserTabActiveCallbacks: [appendMessageToDom('tab-became-active')],
-        idleTimeoutMs: 30000
+        bit.mark('a-mark')
+        bit.mark('b-mark')
+        bit.measure('a-measure', 'a-mark', 'b-mark')
+        printMarks(bit.getMeasures('a-measure'))
       })
-      bit.startTimer()
-
-      window.dispatchEvent(new Event('blur'))
-      window.dispatchEvent(new Event('focus'))
-
-      bit.mark('a-mark')
-      bit.mark('b-mark')
-      bit.measure('a-measure', 'a-mark', 'b-mark')
-      printMarks(bit.getMeasures('a-measure'))
-    })
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/test/e2e/fixtures/timeout.html
+++ b/test/e2e/fixtures/timeout.html
@@ -4,56 +4,54 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html class="no-js">
-<!--<![endif]-->
+  <!--<![endif]-->
 
-<head>
-  <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <title></title>
-  <meta name="description" content="" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="" />
-</head>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title></title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="" />
+  </head>
 
-<body>
-  <h2 class="headline">⏰browser-interaction-time</h2>
-  <script src="../../../dist/browser-interaction-time.umd.js"></script>
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      var appendMessageToDom = text => time => {
-        const element = document.createElement('div')
-        element.className = text
+  <body>
+    <h2 class="headline">⏰browser-interaction-time</h2>
+    <script src="../../../dist/browser-interaction-time.umd.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        var appendMessageToDom = (text) => (time) => {
+          const element = document.createElement('div')
+          element.className = text
 
-        element.innerHTML = `<span>${text}: ${time} ms</span>`
-        document.body.appendChild(element)
-      }
+          element.innerHTML = `<span>${text}: ${time} ms</span>`
+          document.body.appendChild(element)
+        }
 
-      var bit = new window.browserInteractionTime({
-        timeIntervalEllapsedCallbacks: [{
-          timeInMilliseconds: 1000,
-          callback: appendMessageToDom('timer-reached-interval'),
-          multiplier: x => x * 2
-        }],
-        absoluteTimeEllapsedCallbacks: [{
-            timeInMilliseconds: 1000,
-            callback: appendMessageToDom('timer-reached-absolute'),
-            pending: true
-          },
-          {
-            timeInMilliseconds: 9000,
-            callback: appendMessageToDom('timer-reached-absolute'),
-            pending: true
-          }
-        ],
-        browserTabInactiveCallbacks: [
-          appendMessageToDom('tab-became-inactive')
-        ],
-        browserTabActiveCallbacks: [appendMessageToDom('tab-became-active')],
-        idleTimeoutMs: 3000
+        var bit = new window.browserInteractionTime({
+          timeIntervalEllapsedCallbacks: [
+            {
+              timeInMilliseconds: 1000,
+              callback: appendMessageToDom('timer-reached-interval'),
+              multiplier: (x) => x * 2,
+            },
+          ],
+          absoluteTimeEllapsedCallbacks: [
+            {
+              timeInMilliseconds: 1000,
+              callback: appendMessageToDom('timer-reached-absolute'),
+              pending: true,
+            },
+            {
+              timeInMilliseconds: 9000,
+              callback: appendMessageToDom('timer-reached-absolute'),
+              pending: true,
+            },
+          ],
+          idleTimeoutMs: 3000,
+        })
+        bit.startTimer()
       })
-      bit.startTimer()
-    })
-  </script>
-</body>
-
+    </script>
+  </body>
 </html>

--- a/test/e2e/test.ts
+++ b/test/e2e/test.ts
@@ -2,69 +2,55 @@ import { Selector } from 'testcafe'
 
 fixture`Default`.page`./fixtures/index.html`
 
-test(`Test starts up successful`, async t => {
+test(`Test starts up successful`, async (t) => {
   const headline = Selector('.headline').innerText
   await t.expect(headline).eql('⏰browser-interaction-time')
 })
 
 const timerReachedInterval = Selector('.timer-reached-interval').with({
-  timeout: 20000
+  timeout: 20000,
 })
 const timerReachedAbsolute = Selector('.timer-reached-absolute').with({
-  timeout: 20000
-})
-
-const blurSelector = Selector('.tab-became-inactive').with({
-  timeout: 20000
-})
-
-const focusSelector = Selector('.tab-became-active').with({
-  timeout: 20000
+  timeout: 20000,
 })
 
 const measureSelector = Selector('.a-measure').with({
-  timeout: 20000
+  timeout: 20000,
 })
 
-test(`interval callbacks are called when running 1.5s`, async t => {
+test(`interval callbacks are called when running 1.5s`, async (t) => {
   await t.wait(1500)
   await t.expect(await timerReachedInterval.count).eql(1, { timeout: 20000 })
 })
 
-test(`absolute callbacks are called when running 1.5s`, async t => {
+test(`absolute callbacks are called when running 1.5s`, async (t) => {
   await t.wait(1500)
   await t.expect(await timerReachedAbsolute.count).eql(1, { timeout: 20000 })
 })
 
-test(`interval callbacks are called when running 10s`, async t => {
+test(`interval callbacks are called when running 10s`, async (t) => {
   await t.wait(10000)
   await t.expect(await timerReachedInterval.count).eql(4, { timeout: 20000 })
 })
 
-test(`absolute callbacks are called when running 10s`, async t => {
+test(`absolute callbacks are called when running 10s`, async (t) => {
   await t.wait(10000)
   await t.expect(await timerReachedAbsolute.count).eql(2, { timeout: 20000 })
 })
 
-test(`focus and blur callbacks are called`, async t => {
-  await t.wait(1500)
-  await t.expect(await blurSelector.count).eql(1, { timeout: 20000 })
-  await t.expect(await focusSelector.count).eql(1, { timeout: 20000 })
-})
-
-test(`mark and measure works as expected`, async t => {
+test(`mark and measure works as expected`, async (t) => {
   await t.wait(1500)
   await t.expect(await measureSelector.count).eql(1, { timeout: 20000 })
 })
 
 fixture`Timeout`.page`./fixtures/timeout.html`
 
-test(`Test starts up successful`, async t => {
+test(`Test starts up successful`, async (t) => {
   const headline = Selector('.headline').innerText
   await t.expect(headline).eql('⏰browser-interaction-time')
 })
 
-test(`with idleTimeoutMs set to 3000ms only callbacks until 3000ms should be called`, async t => {
+test(`with idleTimeoutMs set to 3000ms only callbacks until 3000ms should be called`, async (t) => {
   await t.wait(10000)
   await t.expect(await timerReachedAbsolute.count).eql(1, { timeout: 20000 })
   await t.expect(await timerReachedInterval.count).eql(2, { timeout: 20000 })

--- a/test/unit/browser-interaction-time.test.ts
+++ b/test/unit/browser-interaction-time.test.ts
@@ -1,6 +1,6 @@
 import BrowserInteractionTime, {
   TimeIntervalEllapsedCallbackData,
-  AbsoluteTimeEllapsedCallbackData
+  AbsoluteTimeEllapsedCallbackData,
 } from '../../src/browser-interaction-time'
 import 'jest-extended'
 
@@ -45,8 +45,8 @@ describe('BrowserInteractionTime', () => {
     })
 
     it('registers event listeners', () => {
-      expect(windowAddEventListenerSpy).toBeCalledTimes(4)
-      expect(documentAddEventListenerSpy).toBeCalledTimes(9)
+      expect(windowAddEventListenerSpy).toBeCalledTimes(2)
+      expect(documentAddEventListenerSpy).toBeCalledTimes(10)
     })
   })
 
@@ -58,11 +58,11 @@ describe('BrowserInteractionTime', () => {
       intervalCallback = {
         timeInMilliseconds: 2000,
         callback: jest.fn(),
-        multiplier: x => x * 2
+        multiplier: (x) => x * 2,
       }
 
       defaultBrowserInteractionTime = new BrowserInteractionTime({
-        timeIntervalEllapsedCallbacks: [intervalCallback]
+        timeIntervalEllapsedCallbacks: [intervalCallback],
       })
     })
 
@@ -99,7 +99,7 @@ describe('BrowserInteractionTime', () => {
       defaultBrowserInteractionTime.mark('mark')
       expect(defaultBrowserInteractionTime.getMarks('mark')).toHaveLength(1)
       expect(defaultBrowserInteractionTime.getMarks('mark')).toEqual([
-        { time: 5000 }
+        { time: 5000 },
       ])
     })
 
@@ -114,8 +114,8 @@ describe('BrowserInteractionTime', () => {
         {
           name: 'measure-a',
           startTime: 5000,
-          duration: 5000
-        }
+          duration: 5000,
+        },
       ])
     })
   })
@@ -129,24 +129,24 @@ describe('BrowserInteractionTime', () => {
         {
           timeInMilliseconds: 2000,
           callback: jest.fn(),
-          pending: true
+          pending: true,
         },
         {
           timeInMilliseconds: 6000,
           callback: jest.fn(),
-          pending: true
-        }
+          pending: true,
+        },
       ]
 
       defaultBrowserInteractionTime = new BrowserInteractionTime({
-        absoluteTimeEllapsedCallbacks: absoluteTimeEllapsedCallbacks
+        absoluteTimeEllapsedCallbacks: absoluteTimeEllapsedCallbacks,
       })
     })
 
     it('no callback is called', () => {
       defaultBrowserInteractionTime.startTimer()
       expect(defaultBrowserInteractionTime.isRunning()).toBe(true)
-      absoluteTimeEllapsedCallbacks.forEach(callbackObject => {
+      absoluteTimeEllapsedCallbacks.forEach((callbackObject) => {
         expect(callbackObject.callback).not.toBeCalled()
       })
     })


### PR DESCRIPTION
BREAKING CHANGE:

Problem:
Blur events get also triggered when interacting with some ui elements like inputs or videos which is not ideal because the timer stops and users get unexpectedly set to inactive. 

Solution: Using https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API

This pull-request replaces the old blur event listeners with the new page visibility api. It is a breaking change because it changes the current behaviour when tabs become active/inactive but it works much better. This event gets only triggered when a window is truly not visible or becomes visible again.


